### PR TITLE
Add ite_ec to meson config options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,7 @@ config_gfxnvidia = get_option('config_gfxnvidia')
 config_raiden_debug_spi = get_option('config_raiden_debug_spi')
 config_internal = get_option('config_internal')
 config_it8212 = get_option('config_it8212')
+config_ite_ec = get_option('config_ite_ec')
 config_linux_mtd = get_option('config_linux_mtd')
 config_linux_spi = get_option('config_linux_spi')
 config_mec1308 = get_option('config_mec1308')
@@ -220,6 +221,11 @@ endif
 if config_it8212
   srcs += 'it8212.c'
   cargs += '-DCONFIG_IT8212=1'
+endif
+if config_ite_ec
+  srcs += 'ite_ec.c'
+  need_raw_access = true
+  cargs += '-DCONFIG_ITE_EC=1'
 endif
 if config_linux_mtd
   srcs += 'linux_mtd.c'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,6 +22,7 @@ option('config_raiden_debug_spi', type : 'boolean', value : true, description : 
 option('config_internal', type : 'boolean', value : true, description : 'internal/onboard')
 option('config_internal_dmi', type : 'boolean', value : true, description : 'Use internal DMI parser')
 option('config_it8212', type : 'boolean', value : true, description : 'ITE IT8212F PATA')
+option('config_ite_ec', type : 'boolean', value : true, description : 'ITE Embedded Controllers')
 option('config_linux_mtd', type : 'boolean', value : true, description : 'Linux MTD interfaces')
 option('config_linux_spi', type : 'boolean', value : true, description : 'Linux spidev interfaces')
 option('config_mec1308', type : 'boolean', value : true, description : 'Microchip MEC1308 Embedded Controller')


### PR DESCRIPTION
Needed to compile with ite_ec support with meson.

Change-Id: I2bbfece09ed03da61d4d4197cdfd4cd90b776f55
Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>